### PR TITLE
E5P2-31 Fix game loop input blocking & disable SFX on init fail

### DIFF
--- a/src/minesweeper.py
+++ b/src/minesweeper.py
@@ -19,6 +19,7 @@ from pfp_helper import save_profile_image  # copy chosen image to assets
 from game_timer import GameTimer # Track game time
 from sfx import SFX
 from ai import ai_solver
+from time import sleep
 
 from settings import (
     clock, screen, WIDTH, HEIGHT,
@@ -433,6 +434,67 @@ while running:
     # Fill background black every frame
     screen.fill(BLACK)
 
+    # Handle AI updates outside the user input processing and response loop
+    if state == PLAYING:
+        # --- AI MOVE (automatic or interactive) ---
+        if ai and not player_turn:
+            sleep(0.5)
+            row, col, action = ai.make_move()
+            if row is not None and col is not None:
+                if action == "reveal":
+                    if not flagged[row][col] and not revealed[row][col]:
+                        if not first_click_done:  # Ensure a mine isn't initially clicked
+                            ensure_first_click_safe(row, col, grid)
+                            sfx.play_square_revealed()
+                            counts = compute_counts(grid)
+                            first_click_done = True
+                            # Start the game timer
+                            game_time.start()
+                        if grid[row][col] == MINE:  # Check for loss
+                            sfx.play_loss()
+                            revealed[row][col] = True
+                            reveal_all_mines(grid, revealed)  # reveal all mines on loss
+                            state = LOSE
+                            # Stop the game timer
+                            game_time.stop()
+                        else:  # Check win condition
+                            sfx.play_square_revealed()
+                            flood_reveal(row, col, grid, counts, revealed, flagged)
+                            revealed[row][col] = True
+                            if check_win(grid, revealed):
+                                state = WIN
+                                sfx.play_win()
+                                start_confetti() # add confetti animation
+                                # Stop the game timer
+                                game_time.stop()
+                                # Calculate and update high score (only for logged-in users since they have a high score and guest doesn't)
+                                if auth.is_logged_in():
+                                    # Get the elapsed time in seconds
+                                    elapsed_seconds = game_time.get_elapsed_time_seconds()
+                                    # Avoid division by zero
+                                    if elapsed_seconds > 0:
+                                        # Calculate the score
+                                        score = (counter_value * 1000) // elapsed_seconds  # Higher score = better
+                                        # Check if the score is a new high score
+                                        is_new_high = auth.set_high_score(score)
+                                        # Show notification if it's a new high score
+                                        if is_new_high:
+                                            # Show notification if it's a new high score (for 3s)
+                                            show_high_score_notification = True # Global toggle
+                                            # Set the notification start time to the current time
+                                            notification_start_time = pygame.time.get_ticks()
+                elif action == "flag":
+                    if not revealed[row][col]:
+                        if flagged[row][col]:
+                            sfx.play_flag_popped()
+                            flagged[row][col] = False
+                        elif get_remaining_flags() > 0:
+                            sfx.play_flag_placed()
+                            flagged[row][col] = True  # flag only if flags remain
+            if mode == AI_INTERACTIVE:
+                player_turn = True
+            # In AUTOMATIC, keep player_turn = False so the AI moves again next frame
+
     # Handle events/inputs
     for event in pygame.event.get():
         if event.type == pygame.QUIT:  # Close window
@@ -530,64 +592,6 @@ while running:
 
         # PLAYING state logic
         elif state == PLAYING:
-            # --- AI MOVE (automatic or interactive) ---
-            if ai and not player_turn:
-                row, col, action = ai.make_move()
-                if row is not None and col is not None:
-                    if action == "reveal":
-                        if not flagged[row][col] and not revealed[row][col]:
-                            if not first_click_done:  # Ensure a mine isn't initially clicked
-                                ensure_first_click_safe(row, col, grid)
-                                sfx.play_square_revealed()
-                                counts = compute_counts(grid)
-                                first_click_done = True
-                                # Start the game timer
-                                game_time.start()
-                            if grid[row][col] == MINE:  # Check for loss
-                                sfx.play_loss()
-                                revealed[row][col] = True
-                                reveal_all_mines(grid, revealed)  # reveal all mines on loss
-                                state = LOSE
-                                # Stop the game timer
-                                game_time.stop()
-                            else:  # Check win condition
-                                sfx.play_square_revealed()
-                                flood_reveal(row, col, grid, counts, revealed, flagged)
-                                revealed[row][col] = True
-                                if check_win(grid, revealed):
-                                    state = WIN
-                                    sfx.play_win()
-                                    start_confetti() # add confetti animation
-                                    # Stop the game timer
-                                    game_time.stop()
-                                    # Calculate and update high score (only for logged-in users since they have a high score and guest doesn't)
-                                    if auth.is_logged_in():
-                                        # Get the elapsed time in seconds
-                                        elapsed_seconds = game_time.get_elapsed_time_seconds()
-                                        # Avoid division by zero
-                                        if elapsed_seconds > 0:
-                                            # Calculate the score
-                                            score = (counter_value * 1000) // elapsed_seconds  # Higher score = better
-                                            # Check if the score is a new high score
-                                            is_new_high = auth.set_high_score(score)
-                                            # Show notification if it's a new high score
-                                            if is_new_high:
-                                                # Show notification if it's a new high score (for 3s)
-                                                show_high_score_notification = True # Global toggle
-                                                # Set the notification start time to the current time
-                                                notification_start_time = pygame.time.get_ticks()
-                    elif action == "flag":
-                        if not revealed[row][col]:
-                            if flagged[row][col]:
-                                sfx.play_flag_popped()
-                                flagged[row][col] = False
-                            elif get_remaining_flags() > 0:
-                                sfx.play_flag_placed()
-                                flagged[row][col] = True  # flag only if flags remain
-                if mode == AI_INTERACTIVE:
-                    player_turn = True
-                # In AUTOMATIC, keep player_turn = False so the AI moves again next frame
-
             # --- PLAYER INPUT ---
             if event.type == pygame.MOUSEBUTTONDOWN and mode != AI_AUTOMATIC:
                 mouse_x, mouse_y = event.pos  # get coordinates of mouse

--- a/src/sfx.py
+++ b/src/sfx.py
@@ -11,35 +11,46 @@ class SFX:
         self.music_channel = mixer.Channel(1)
         mixer.set_reserved(1)
         self.music_channel.set_volume(0.1)
+        self.enabled = True
 
-        background_music_choice = random.choice(os.listdir(os.path.join(SOUND_DIR, "bgmusic")))
-        print(f"{os.path.join(SOUND_DIR, 'bgmusic', background_music_choice)}")
-        self.background_music = mixer.Sound(os.path.join(SOUND_DIR, "bgmusic", background_music_choice))
+        try:
+            background_music_choice = random.choice(os.listdir(os.path.join(SOUND_DIR, "bgmusic")))
+            print(f"{os.path.join(SOUND_DIR, 'bgmusic', background_music_choice)}")
+            self.background_music = mixer.Sound(os.path.join(SOUND_DIR, "bgmusic", background_music_choice))
 
-        self.bomb_clicked_sound = mixer.Sound(os.path.join(SOUND_DIR,"bomb-clicked.mp3"))
-        self.flag_placed_sound = mixer.Sound(os.path.join(SOUND_DIR,"flag-placed.mp3"))
-        self.loss_sound = mixer.Sound(os.path.join(SOUND_DIR,"loss.mp3"))
-        self.win_sound = mixer.Sound(os.path.join(SOUND_DIR,"win.mp3"))
-        self.square_revealed_sound = mixer.Sound(os.path.join(SOUND_DIR,"square-revealed.mp3"))
-        self.flagg_popped_sound = mixer.Sound(os.path.join(SOUND_DIR, "flag-popped.mp3"))
+            self.bomb_clicked_sound = mixer.Sound(os.path.join(SOUND_DIR,"bomb-clicked.mp3"))
+            self.flag_placed_sound = mixer.Sound(os.path.join(SOUND_DIR,"flag-placed.mp3"))
+            self.loss_sound = mixer.Sound(os.path.join(SOUND_DIR,"loss.mp3"))
+            self.win_sound = mixer.Sound(os.path.join(SOUND_DIR,"win.mp3"))
+            self.square_revealed_sound = mixer.Sound(os.path.join(SOUND_DIR,"square-revealed.mp3"))
+            self.flagg_popped_sound = mixer.Sound(os.path.join(SOUND_DIR, "flag-popped.mp3"))
+        except:
+            self.enabled = False
 
     def ensure_bgmusic(self):
-        if not self.music_channel.get_busy():
+        if not self.music_channel.get_busy() and self.enabled:
             self.start_bgmusic()
 
     def play_flag_placed(self):
-        self.sfx_channel.play(self.flag_placed_sound)
+        if self.enabled:
+            self.sfx_channel.play(self.flag_placed_sound)
     def play_bomb_clicked(self):
-        self.sfx_channel.play(self.bomb_clicked_sound)
+        if self.enabled:
+            self.sfx_channel.play(self.bomb_clicked_sound)
     def play_win(self):
-        self.sfx_channel.play(self.win_sound)
+        if self.enabled:
+            self.sfx_channel.play(self.win_sound)
     def play_loss(self):
-        self.sfx_channel.play(self.loss_sound)
+        if self.enabled:
+            self.sfx_channel.play(self.loss_sound)
     def play_square_revealed(self):
-        self.sfx_channel.play(self.square_revealed_sound)
+        if self.enabled:
+            self.sfx_channel.play(self.square_revealed_sound)
     def play_flag_popped(self):
-        self.sfx_channel.play(self.flagg_popped_sound)
+        if self.enabled:
+            self.sfx_channel.play(self.flagg_popped_sound)
     def start_bgmusic(self):
-        self.music_channel.play(self.background_music, loops=-1)
+        if self.enabled:
+            self.music_channel.play(self.background_music, loops=-1)
 
 


### PR DESCRIPTION
User no longer needs to perform some sort of input action (i.e. move the mouse) to trigger the AI to make a move. AI moves also no operate on a 0.5 sec delay. SFX will now disable itself if it fails on init. 