### PR TITLE
Add dark-light mode toggle logic, ensure music screen is invisible on settings, signup, pfp setup pages

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -12,8 +12,8 @@ class AuthContext:
     {
       "current_user": "alice" | "",
       "users": {
-        "alice": {"token": "...", "pfp_path": "...", "high_score": 0},
-        "bob": {"token": "...", "pfp_path": "...", "high_score": 0}
+        "alice": {"token": "...", "pfp_path": "...", "high_score": 0, "theme": "light"},
+        "bob": {"token": "...", "pfp_path": "...", "high_score": 100, "theme": "dark"}
       }
     }
     """
@@ -152,4 +152,34 @@ class AuthContext:
             rec = users.get(cu) or {}
             rec["token"] = ""
         self._store["current_user"] = ""
+        self._save_user()
+
+    def get_theme_preference(self) -> str:
+        # Get the current user
+        cu = self._store.get("current_user") or ""
+        # Get the users dictionary
+        users = self._store.get("users", {})
+        # If the current user exists and the users dictionary is a dictionary, get the record for the current user
+        if cu and isinstance(users, dict):
+            # Get the record for the current user
+            rec = users.get(cu) or {}
+            # Get the theme preference from the record
+            theme = rec.get("theme", "dark")
+            # If the theme preference is in the list of allowed themes, return it, otherwise return dark
+            return theme if theme in ["dark", "light"] else "dark"
+        # If the current user does not exist or the users dictionary is not a dictionary, return dark
+        return "dark"  # Guest users get dark mode
+
+    def set_theme_preference(self, theme: str) -> None:
+        # Set the current user's theme preference
+        cu = self._store.get("current_user") or ""
+        if not cu:
+            return  # Guest users can't save preferences
+        # Get the users dictionary
+        users = self._store.setdefault("users", {})
+        # Get the record for the current user
+        rec = users.setdefault(cu, {"token": "", "pfp_path": "", "high_score": 0, "theme": "dark"})
+        # Set the theme preference in the record
+        rec["theme"] = theme if theme in ["dark", "light"] else "dark"
+        # Save the user to the store
         self._save_user()

--- a/src/button.py
+++ b/src/button.py
@@ -1,5 +1,5 @@
 import pygame
-from settings import WHITE
+from settings import WHITE, get_current_theme
 # Button Class
 class Button:
     def __init__(self, x, y, w, h, text, color, hover_color, text_color=WHITE):
@@ -15,11 +15,23 @@ class Button:
         mouse_pos = pygame.mouse.get_pos()
         is_hovered = self.rect.collidepoint(mouse_pos)
 
+        # Get theme-appropriate colors for gray buttons in light mode
+        theme = get_current_theme()
+        button_color = self.color
+        hover_color = self.hover_color
+        
+        # If this is a gray button in light theme, use lighter colors
+        if (theme['background'] == (245, 245, 220) and  # Light theme
+            self.color == (100, 100, 100)):  # Gray button
+            button_color = theme['light_button_bg']
+            hover_color = theme['light_button_hover']
+
         # Draw rectangle (with hover effect)
-        pygame.draw.rect(surface, self.hover_color if is_hovered else self.color, self.rect, border_radius=10)
+        pygame.draw.rect(surface, hover_color if is_hovered else button_color, self.rect, border_radius=10)
 
         # Draw text centered inside the button
-        text_surf = font.render(self.text, True, self.text_color)
+        text_color = self.text_color if self.text_color != WHITE else get_current_theme()['text']
+        text_surf = font.render(self.text, True, text_color)
         text_rect = text_surf.get_rect(center=self.rect.center)
         surface.blit(text_surf, text_rect)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -72,6 +72,48 @@ DIRS8 = [(-1, -1), (-1, 0), (-1, 1),
 
 CONFETTI_TARGET = 180 # Set number of particles to generation
 
+# Theme system
+DARK_THEME = {
+    'background': (0, 0, 0),          # BLACK
+    'text': (255, 255, 255),          # WHITE  
+    'grid_tile': (100, 100, 100),     # GRAY
+    'grid_revealed': (200, 200, 200), # LIGHT_GRAY
+    'grid_border': (0, 0, 0),         # BLACK
+    'button_bg': (100, 100, 100),     # GRAY
+    'button_hover': (150, 150, 150),  # Lighter gray
+    'notification_bg': (45, 45, 45),  # Dark gray for message boxes
+    'notification_border': (255, 255, 255), # WHITE border
+}
+
+LIGHT_THEME = {
+    'background': (245, 245, 220),    # Beige
+    'text': (32, 32, 32),            # Much darker gray for better readability
+    'grid_tile': (180, 180, 180),    # Medium gray - more contrast
+    'grid_revealed': (255, 255, 255), # Pure white - maximum contrast
+    'grid_border': (64, 64, 64),     # Dark gray
+    'button_bg': (200, 200, 200),    # Light gray
+    'button_hover': (180, 180, 180), # Darker gray
+    'light_button_bg': (150, 150, 150), # Lighter gray for better contrast
+    'light_button_hover': (130, 130, 130), # Even lighter hover
+    'notification_bg': (220, 220, 220), # Light gray for message boxes
+    'notification_border': (64, 64, 64), # Dark gray border
+}
+
+# Current theme (defaults to dark)
+current_theme = DARK_THEME
+
+def switch_theme(theme_name):
+    """Switch between dark and light themes"""
+    global current_theme
+    if theme_name == "dark":
+        current_theme = DARK_THEME
+    else:
+        current_theme = LIGHT_THEME
+
+def get_current_theme():
+    """Get the current theme dictionary"""
+    return current_theme
+
 
 
 


### PR DESCRIPTION
Light mode:
<img width="863" height="683" alt="image" src="https://github.com/user-attachments/assets/64014a13-541e-48ee-899c-c8bac70f62b6" />

Light mode - Game Screen: 
<img width="854" height="679" alt="image" src="https://github.com/user-attachments/assets/d5b6c68d-4c25-4a7c-b3d9-d9ea9dc3c200" />
